### PR TITLE
Add modules for booking_settings, spot, venue_rules, work_station, and user_streak

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,8 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/typeorm": "^11.0.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
         "pg": "^8.14.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -3396,6 +3398,12 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.12.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.3.tgz",
+      "integrity": "sha512-2ipwZ2NydGQJImne+FhNdhgRM37e9lCev99KnqkbFHd94Xn/mErARWI1RSLem1QA19ch5kOhzIZd7e8CA2FI8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -4808,6 +4816,23 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.10.53",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -7988,6 +8013,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.6.tgz",
+      "integrity": "sha512-PJiS4ETaUfCOFLpmtKzAbqZQjCCKVu2OhTV4SVNNE7c2nu/dACvtCqj4L0i/KWNnIgRv7yrILvBj5Lonv5Ncxw==",
+      "license": "MIT"
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -11224,6 +11255,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.0.tgz",
+      "integrity": "sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,8 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/typeorm": "^11.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "pg": "^8.14.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -5,6 +5,11 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from './datasource/typeorm.module';
 import { UsersModule } from './users/users.module';
 import { VenueModule } from './venue/venue.module';
+import { BookingSettingsModule } from './booking_settings/booking_settings.module';
+import { SpotModule } from './spot/spot.module';
+import { WorkStationModule } from './work_station/work_station.module';
+import { VenueRulesModule } from './venue_rules/venue_rules.module';
+import { UserStreakModule } from './user_streak/user_streak.module';
 
 @Module({
   imports: [
@@ -15,6 +20,11 @@ import { VenueModule } from './venue/venue.module';
     }),
     UsersModule,
     VenueModule,
+    BookingSettingsModule,
+    SpotModule,
+    WorkStationModule,
+    VenueRulesModule,
+    UserStreakModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/server/src/booking_settings/booking_settings.controller.spec.ts
+++ b/server/src/booking_settings/booking_settings.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BookingSettingsController } from './booking_settings.controller';
+
+describe('BookingSettingsController', () => {
+  let controller: BookingSettingsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BookingSettingsController],
+    }).compile();
+
+    controller = module.get<BookingSettingsController>(BookingSettingsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/booking_settings/booking_settings.controller.ts
+++ b/server/src/booking_settings/booking_settings.controller.ts
@@ -1,0 +1,41 @@
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { BookingSettingsService } from './booking_settings.service';
+import { BookingSettings } from './booking_settings.entity';
+
+@Controller('booking-settings')
+export class BookingSettingsController {
+  constructor(private readonly bookingSettingsService: BookingSettingsService) {}
+
+  @Get()
+  findAll(): Promise<BookingSettings[]> {
+    return this.bookingSettingsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<BookingSettings> {
+    return this.bookingSettingsService.findOne(id);
+  }
+
+  @Get('venue/:venueId')
+  findByVenue(@Param('venueId') venueId: string): Promise<BookingSettings> {
+    return this.bookingSettingsService.findByVenue(venueId);
+  }
+
+  @Post()
+  create(@Body() bookingSettings: Partial<BookingSettings>): Promise<BookingSettings> {
+    return this.bookingSettingsService.create(bookingSettings);
+  }
+
+  @Put(':id')
+  update(
+    @Param('id') id: string,
+    @Body() bookingSettings: Partial<BookingSettings>,
+  ): Promise<BookingSettings> {
+    return this.bookingSettingsService.update(id, bookingSettings);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string): Promise<void> {
+    return this.bookingSettingsService.remove(id);
+  }
+}

--- a/server/src/booking_settings/booking_settings.entity.ts
+++ b/server/src/booking_settings/booking_settings.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Venue } from '../venue/venue.entity';
+
+@Entity('booking_settings')
+export class BookingSettings {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'jsonb', name: 'visibilty_rules' })
+  visibiltyRules: any;
+
+  @Column({ name: 'lock_in_policy' })
+  lockInPolicy: string;
+
+  @Column({ name: 'allow_repeat' })
+  allowRepeat: boolean;
+
+  @Column({ name: 'allow_spot_swap' })
+  allowSpotSwap: boolean;
+
+  @ManyToOne(() => Venue)
+  @JoinColumn({ name: 'venue' })
+  venue: Venue;
+} 

--- a/server/src/booking_settings/booking_settings.module.ts
+++ b/server/src/booking_settings/booking_settings.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BookingSettingsService } from './booking_settings.service';
+import { BookingSettingsController } from './booking_settings.controller';
+import { BookingSettings } from './booking_settings.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([BookingSettings])],
+  providers: [BookingSettingsService],
+  controllers: [BookingSettingsController],
+  exports: [BookingSettingsService]
+})
+export class BookingSettingsModule {}

--- a/server/src/booking_settings/booking_settings.service.spec.ts
+++ b/server/src/booking_settings/booking_settings.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BookingSettingsService } from './booking_settings.service';
+
+describe('BookingSettingsService', () => {
+  let service: BookingSettingsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BookingSettingsService],
+    }).compile();
+
+    service = module.get<BookingSettingsService>(BookingSettingsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/booking_settings/booking_settings.service.ts
+++ b/server/src/booking_settings/booking_settings.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BookingSettings } from './booking_settings.entity';
+
+@Injectable()
+export class BookingSettingsService {
+  constructor(
+    @InjectRepository(BookingSettings)
+    private bookingSettingsRepository: Repository<BookingSettings>,
+  ) {}
+
+  async findAll(): Promise<BookingSettings[]> {
+    return this.bookingSettingsRepository.find();
+  }
+
+  async findOne(id: string): Promise<BookingSettings> {
+    const bookingSettings = await this.bookingSettingsRepository.findOne({ where: { id } });
+    if (!bookingSettings) {
+      throw new NotFoundException(`Booking settings with ID ${id} not found`);
+    }
+    return bookingSettings;
+  }
+
+  async findByVenue(venueId: string): Promise<BookingSettings> {
+    const bookingSettings = await this.bookingSettingsRepository.findOne({ 
+      where: { venue: { id: venueId } },
+      relations: ['venue']
+    });
+    if (!bookingSettings) {
+      throw new NotFoundException(`Booking settings for venue with ID ${venueId} not found`);
+    }
+    return bookingSettings;
+  }
+
+  async create(bookingSettings: Partial<BookingSettings>): Promise<BookingSettings> {
+    const newBookingSettings = this.bookingSettingsRepository.create(bookingSettings);
+    return this.bookingSettingsRepository.save(newBookingSettings);
+  }
+
+  async update(id: string, bookingSettings: Partial<BookingSettings>): Promise<BookingSettings> {
+    await this.bookingSettingsRepository.update(id, bookingSettings);
+    return this.findOne(id);
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.bookingSettingsRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Booking settings with ID ${id} not found`);
+    }
+  }
+}

--- a/server/src/spot/dto/create-spot.dto.ts
+++ b/server/src/spot/dto/create-spot.dto.ts
@@ -1,0 +1,14 @@
+import { IsBoolean, IsNotEmpty, IsObject, IsUUID } from 'class-validator';
+
+export class CreateSpotDto {
+  @IsBoolean()
+  @IsNotEmpty()
+  isAvailable: boolean;
+
+  @IsObject()
+  bookedUser: any;
+
+  @IsUUID()
+  @IsNotEmpty()
+  workStation: string;
+} 

--- a/server/src/spot/spot.controller.spec.ts
+++ b/server/src/spot/spot.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SpotController } from './spot.controller';
+
+describe('SpotController', () => {
+  let controller: SpotController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SpotController],
+    }).compile();
+
+    controller = module.get<SpotController>(SpotController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/spot/spot.controller.ts
+++ b/server/src/spot/spot.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { SpotService } from './spot.service';
+import { CreateSpotDto } from './dto/create-spot.dto';
+import { Spot } from './spot.entity';
+
+@Controller('spot')
+export class SpotController {
+  constructor(private readonly spotService: SpotService) {}
+
+  @Post()
+  create(@Body() createSpotDto: CreateSpotDto): Promise<Spot> {
+    return this.spotService.create(createSpotDto);
+  }
+
+  @Get()
+  findAll(): Promise<Spot[]> {
+    return this.spotService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<Spot> {
+    return this.spotService.findOne(id);
+  }
+
+  @Get('work-station/:workStationId')
+  findByWorkStation(@Param('workStationId') workStationId: string): Promise<Spot[]> {
+    return this.spotService.findByWorkStation(workStationId);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateSpotDto: Partial<CreateSpotDto>,
+  ): Promise<Spot> {
+    return this.spotService.update(id, updateSpotDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string): Promise<void> {
+    return this.spotService.remove(id);
+  }
+}

--- a/server/src/spot/spot.entity.ts
+++ b/server/src/spot/spot.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { WorkStation } from '../work_station/work_station.entity';
+
+@Entity('spot')
+export class Spot {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'is_available' })
+  isAvailable: boolean;
+
+  @Column({ name: 'booked_user', type: 'json' })
+  bookedUser: any;
+
+  @ManyToOne(() => WorkStation)
+  @JoinColumn({ name: 'work_station' })
+  workStation: WorkStation;
+
+  @Column({ name: 'created_at', type: 'date' })
+  createdAt: Date;
+
+  @Column({ name: 'updated_at' })
+  updatedAt: number;
+} 

--- a/server/src/spot/spot.module.ts
+++ b/server/src/spot/spot.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SpotService } from './spot.service';
+import { SpotController } from './spot.controller';
+import { Spot } from './spot.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Spot])],
+  controllers: [SpotController],
+  providers: [SpotService],
+  exports: [SpotService]
+})
+export class SpotModule {}

--- a/server/src/spot/spot.service.spec.ts
+++ b/server/src/spot/spot.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SpotService } from './spot.service';
+
+describe('SpotService', () => {
+  let service: SpotService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SpotService],
+    }).compile();
+
+    service = module.get<SpotService>(SpotService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/spot/spot.service.ts
+++ b/server/src/spot/spot.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Spot } from './spot.entity';
+import { CreateSpotDto } from './dto/create-spot.dto';
+
+@Injectable()
+export class SpotService {
+  constructor(
+    @InjectRepository(Spot)
+    private spotRepository: Repository<Spot>,
+  ) {}
+
+  async findAll(): Promise<Spot[]> {
+    return this.spotRepository.find({
+      relations: ['workStation'],
+    });
+  }
+
+  async findOne(id: string): Promise<Spot> {
+    const spot = await this.spotRepository.findOne({
+      where: { id },
+      relations: ['workStation'],
+    });
+    if (!spot) {
+      throw new NotFoundException(`Spot with ID ${id} not found`);
+    }
+    return spot;
+  }
+
+  async findByWorkStation(workStationId: string): Promise<Spot[]> {
+    return this.spotRepository.find({
+      where: { workStation: { id: workStationId } },
+      relations: ['workStation'],
+    });
+  }
+
+  async create(createSpotDto: CreateSpotDto): Promise<Spot> {
+    const spot = this.spotRepository.create({
+      isAvailable: createSpotDto.isAvailable,
+      bookedUser: createSpotDto.bookedUser,
+      workStation: { id: createSpotDto.workStation },
+      createdAt: new Date(),
+      updatedAt: Date.now(),
+    });
+    return this.spotRepository.save(spot);
+  }
+
+  async update(id: string, updateSpotDto: Partial<CreateSpotDto>): Promise<Spot> {
+    const spot = await this.findOne(id);
+    
+    if (updateSpotDto.isAvailable !== undefined) {
+      spot.isAvailable = updateSpotDto.isAvailable;
+    }
+    
+    if (updateSpotDto.bookedUser) {
+      spot.bookedUser = updateSpotDto.bookedUser;
+    }
+    
+    if (updateSpotDto.workStation) {
+      spot.workStation = { id: updateSpotDto.workStation } as any;
+    }
+    
+    spot.updatedAt = Date.now();
+    
+    return this.spotRepository.save(spot);
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.spotRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Spot with ID ${id} not found`);
+    }
+  }
+}

--- a/server/src/user_streak/user_streak.controller.spec.ts
+++ b/server/src/user_streak/user_streak.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserStreakController } from './user_streak.controller';
+
+describe('UserStreakController', () => {
+  let controller: UserStreakController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserStreakController],
+    }).compile();
+
+    controller = module.get<UserStreakController>(UserStreakController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/user_streak/user_streak.controller.ts
+++ b/server/src/user_streak/user_streak.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { UserStreakService } from './user_streak.service';
+import { UserStreak } from './user_streak.entity';
+
+@Controller('user-streak')
+export class UserStreakController {
+  constructor(private readonly userStreakService: UserStreakService) {}
+
+  @Post()
+  create(@Body() createUserStreakDto: any): Promise<UserStreak> {
+    return this.userStreakService.create(createUserStreakDto);
+  }
+
+  @Get()
+  findAll(): Promise<UserStreak[]> {
+    return this.userStreakService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<UserStreak> {
+    return this.userStreakService.findOne(id);
+  }
+
+  @Get('user/:userId')
+  findByUser(@Param('userId') userId: string): Promise<UserStreak> {
+    return this.userStreakService.findByUser(userId);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateUserStreakDto: any,
+  ): Promise<UserStreak> {
+    return this.userStreakService.update(id, updateUserStreakDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string): Promise<void> {
+    return this.userStreakService.remove(id);
+  }
+
+  @Post('increment/:userId')
+  incrementStreak(@Param('userId') userId: string): Promise<UserStreak> {
+    return this.userStreakService.incrementStreak(userId);
+  }
+
+  @Post('reset/:userId')
+  resetStreak(@Param('userId') userId: string): Promise<UserStreak> {
+    return this.userStreakService.resetStreak(userId);
+  }
+}

--- a/server/src/user_streak/user_streak.entity.ts
+++ b/server/src/user_streak/user_streak.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { User } from '../users/user.entity';
+
+@Entity('user_streak')
+export class UserStreak {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'user' })
+  user: User;
+
+  @Column({ name: 'last_activity_date', type: 'date' })
+  lastActivityDate: Date;
+
+  @Column({ name: 'streak_count' })
+  streakCount: number;
+
+  @Column({ name: 'highest_streak' })
+  highestStreak: number;
+} 

--- a/server/src/user_streak/user_streak.module.ts
+++ b/server/src/user_streak/user_streak.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserStreakService } from './user_streak.service';
+import { UserStreakController } from './user_streak.controller';
+import { UserStreak } from './user_streak.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserStreak])],
+  controllers: [UserStreakController],
+  providers: [UserStreakService],
+  exports: [UserStreakService]
+})
+export class UserStreakModule {}

--- a/server/src/user_streak/user_streak.service.spec.ts
+++ b/server/src/user_streak/user_streak.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserStreakService } from './user_streak.service';
+
+describe('UserStreakService', () => {
+  let service: UserStreakService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserStreakService],
+    }).compile();
+
+    service = module.get<UserStreakService>(UserStreakService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/user_streak/user_streak.service.ts
+++ b/server/src/user_streak/user_streak.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserStreak } from './user_streak.entity';
+
+@Injectable()
+export class UserStreakService {
+  constructor(
+    @InjectRepository(UserStreak)
+    private userStreakRepository: Repository<UserStreak>,
+  ) {}
+
+  async findAll(): Promise<UserStreak[]> {
+    return this.userStreakRepository.find({
+      relations: ['user'],
+    });
+  }
+
+  async findOne(id: string): Promise<UserStreak> {
+    const userStreak = await this.userStreakRepository.findOne({
+      where: { id },
+      relations: ['user'],
+    });
+    
+    if (!userStreak) {
+      throw new NotFoundException(`User streak with ID ${id} not found`);
+    }
+    
+    return userStreak;
+  }
+
+  async findByUser(userId: string): Promise<UserStreak> {
+    const userStreak = await this.userStreakRepository.findOne({
+      where: { user: { id: userId } },
+      relations: ['user'],
+    });
+    
+    if (!userStreak) {
+      throw new NotFoundException(`User streak for user with ID ${userId} not found`);
+    }
+    
+    return userStreak;
+  }
+
+  async create(createUserStreakDto: any): Promise<UserStreak> {
+    const userStreak = this.userStreakRepository.create({
+      user: { id: createUserStreakDto.user },
+      lastActivityDate: createUserStreakDto.lastActivityDate,
+      streakCount: createUserStreakDto.streakCount,
+      highestStreak: createUserStreakDto.highestStreak,
+    });
+    
+    return this.userStreakRepository.save(userStreak);
+  }
+
+  async update(id: string, updateUserStreakDto: any): Promise<UserStreak> {
+    const userStreak = await this.findOne(id);
+    
+    if (updateUserStreakDto.user) {
+      userStreak.user = { id: updateUserStreakDto.user } as any;
+    }
+    
+    if (updateUserStreakDto.lastActivityDate) {
+      userStreak.lastActivityDate = updateUserStreakDto.lastActivityDate;
+    }
+    
+    if (updateUserStreakDto.streakCount !== undefined) {
+      userStreak.streakCount = updateUserStreakDto.streakCount;
+    }
+    
+    if (updateUserStreakDto.highestStreak !== undefined) {
+      userStreak.highestStreak = updateUserStreakDto.highestStreak;
+    }
+    
+    return this.userStreakRepository.save(userStreak);
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.userStreakRepository.delete(id);
+    
+    if (result.affected === 0) {
+      throw new NotFoundException(`User streak with ID ${id} not found`);
+    }
+  }
+
+  async incrementStreak(userId: string): Promise<UserStreak> {
+    const userStreak = await this.findByUser(userId);
+    
+    userStreak.streakCount += 1;
+    userStreak.lastActivityDate = new Date();
+    
+    if (userStreak.streakCount > userStreak.highestStreak) {
+      userStreak.highestStreak = userStreak.streakCount;
+    }
+    
+    return this.userStreakRepository.save(userStreak);
+  }
+
+  async resetStreak(userId: string): Promise<UserStreak> {
+    const userStreak = await this.findByUser(userId);
+    
+    userStreak.streakCount = 0;
+    userStreak.lastActivityDate = new Date();
+    
+    return this.userStreakRepository.save(userStreak);
+  }
+}

--- a/server/src/venue_rules/venue_rules.controller.spec.ts
+++ b/server/src/venue_rules/venue_rules.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { VenueRulesController } from './venue_rules.controller';
+
+describe('VenueRulesController', () => {
+  let controller: VenueRulesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [VenueRulesController],
+    }).compile();
+
+    controller = module.get<VenueRulesController>(VenueRulesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/venue_rules/venue_rules.controller.ts
+++ b/server/src/venue_rules/venue_rules.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, ParseIntPipe } from '@nestjs/common';
+import { VenueRulesService } from './venue_rules.service';
+import { VenueRules } from './venue_rules.entity';
+
+@Controller('venue-rules')
+export class VenueRulesController {
+  constructor(private readonly venueRulesService: VenueRulesService) {}
+
+  @Post()
+  create(@Body() createVenueRulesDto: any): Promise<VenueRules> {
+    return this.venueRulesService.create(createVenueRulesDto);
+  }
+
+  @Get()
+  findAll(): Promise<VenueRules[]> {
+    return this.venueRulesService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number): Promise<VenueRules> {
+    return this.venueRulesService.findOne(id);
+  }
+
+  @Get('venue/:venueId')
+  findByVenue(@Param('venueId') venueId: string): Promise<VenueRules[]> {
+    return this.venueRulesService.findByVenue(venueId);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateVenueRulesDto: any,
+  ): Promise<VenueRules> {
+    return this.venueRulesService.update(id, updateVenueRulesDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    return this.venueRulesService.remove(id);
+  }
+}

--- a/server/src/venue_rules/venue_rules.entity.ts
+++ b/server/src/venue_rules/venue_rules.entity.ts
@@ -1,0 +1,12 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Venue } from '../venue/venue.entity';
+
+@Entity('venue_rules')
+export class VenueRules {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Venue)
+  @JoinColumn({ name: 'venue' })
+  venue: Venue;
+} 

--- a/server/src/venue_rules/venue_rules.module.ts
+++ b/server/src/venue_rules/venue_rules.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { VenueRulesService } from './venue_rules.service';
+import { VenueRulesController } from './venue_rules.controller';
+import { VenueRules } from './venue_rules.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([VenueRules])],
+  controllers: [VenueRulesController],
+  providers: [VenueRulesService],
+  exports: [VenueRulesService]
+})
+export class VenueRulesModule {}

--- a/server/src/venue_rules/venue_rules.service.spec.ts
+++ b/server/src/venue_rules/venue_rules.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { VenueRulesService } from './venue_rules.service';
+
+describe('VenueRulesService', () => {
+  let service: VenueRulesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [VenueRulesService],
+    }).compile();
+
+    service = module.get<VenueRulesService>(VenueRulesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/venue_rules/venue_rules.service.ts
+++ b/server/src/venue_rules/venue_rules.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { VenueRules } from './venue_rules.entity';
+
+@Injectable()
+export class VenueRulesService {
+  constructor(
+    @InjectRepository(VenueRules)
+    private venueRulesRepository: Repository<VenueRules>,
+  ) {}
+
+  async findAll(): Promise<VenueRules[]> {
+    return this.venueRulesRepository.find({
+      relations: ['venue'],
+    });
+  }
+
+  async findOne(id: number): Promise<VenueRules> {
+    const venueRules = await this.venueRulesRepository.findOne({
+      where: { id },
+      relations: ['venue'],
+    });
+    
+    if (!venueRules) {
+      throw new NotFoundException(`Venue rules with ID ${id} not found`);
+    }
+    
+    return venueRules;
+  }
+
+  async findByVenue(venueId: string): Promise<VenueRules[]> {
+    return this.venueRulesRepository.find({
+      where: { venue: { id: venueId } },
+      relations: ['venue'],
+    });
+  }
+
+  async create(createVenueRulesDto: any): Promise<VenueRules> {
+    const venueRules = this.venueRulesRepository.create({
+      venue: { id: createVenueRulesDto.venue },
+    });
+    
+    return this.venueRulesRepository.save(venueRules);
+  }
+
+  async update(id: number, updateVenueRulesDto: any): Promise<VenueRules> {
+    const venueRules = await this.findOne(id);
+    
+    if (updateVenueRulesDto.venue) {
+      venueRules.venue = { id: updateVenueRulesDto.venue } as any;
+    }
+    
+    return this.venueRulesRepository.save(venueRules);
+  }
+
+  async remove(id: number): Promise<void> {
+    const result = await this.venueRulesRepository.delete(id);
+    
+    if (result.affected === 0) {
+      throw new NotFoundException(`Venue rules with ID ${id} not found`);
+    }
+  }
+}

--- a/server/src/work_station/work_station.controller.spec.ts
+++ b/server/src/work_station/work_station.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkStationController } from './work_station.controller';
+
+describe('WorkStationController', () => {
+  let controller: WorkStationController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WorkStationController],
+    }).compile();
+
+    controller = module.get<WorkStationController>(WorkStationController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/work_station/work_station.controller.ts
+++ b/server/src/work_station/work_station.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('work-station')
+export class WorkStationController {}

--- a/server/src/work_station/work_station.entity.ts
+++ b/server/src/work_station/work_station.entity.ts
@@ -1,0 +1,34 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, OneToMany } from 'typeorm';
+import { Venue } from '../venue/venue.entity';
+import { Spot } from '../spot/spot.entity';
+
+@Entity('work_station')
+export class WorkStation {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ name: 'street_address' })
+  streetAddress: string;
+
+  @Column()
+  city: string;
+
+  @Column({ name: 'zip_code' })
+  zipCode: number;
+
+  @ManyToOne(() => Venue)
+  @JoinColumn({ name: 'venue_id' })
+  venue: Venue;
+
+  @Column({ name: 'created_at', type: 'date' })
+  createdAt: Date;
+
+  @Column({ name: 'updated_at', type: 'date' })
+  updatedAt: Date;
+
+  @OneToMany(() => Spot, spot => spot.workStation)
+  spots: Spot[];
+} 

--- a/server/src/work_station/work_station.module.ts
+++ b/server/src/work_station/work_station.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WorkStationService } from './work_station.service';
+import { WorkStationController } from './work_station.controller';
+import { WorkStation } from './work_station.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WorkStation])],
+  controllers: [WorkStationController],
+  providers: [WorkStationService],
+  exports: [WorkStationService]
+})
+export class WorkStationModule {}

--- a/server/src/work_station/work_station.service.spec.ts
+++ b/server/src/work_station/work_station.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkStationService } from './work_station.service';
+
+describe('WorkStationService', () => {
+  let service: WorkStationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WorkStationService],
+    }).compile();
+
+    service = module.get<WorkStationService>(WorkStationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/work_station/work_station.service.ts
+++ b/server/src/work_station/work_station.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class WorkStationService {}

--- a/server/test-db-connection.js
+++ b/server/test-db-connection.js
@@ -1,0 +1,32 @@
+require('dotenv').config({ path: '../.env' });
+const { Client } = require('pg');
+
+async function testConnection() {
+  const client = new Client({
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT,
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+  });
+
+  try {
+    console.log('Attempting to connect to PostgreSQL database...');
+    console.log(`Host: ${process.env.DB_HOST}`);
+    console.log(`Port: ${process.env.DB_PORT}`);
+    console.log(`User: ${process.env.DB_USERNAME}`);
+    console.log(`Database: ${process.env.DB_NAME}`);
+    
+    await client.connect();
+    console.log('Connection successful! Database is up and running.');
+    
+    const res = await client.query('SELECT NOW()');
+    console.log('Current database time:', res.rows[0].now);
+    
+    await client.end();
+  } catch (err) {
+    console.error('Error connecting to the database:', err);
+  }
+}
+
+testConnection(); 


### PR DESCRIPTION
### **Description:** 

This PR adds the following modules:

- booking_settings: Handles booking settings for venues.
- spot: Manages spots available for booking.
- venue_rules: Contains rules associated with venues.
- work_station: Represents workstations within venues.
- user_streak: Tracks user activity streaks.