### PR TITLE
feat: implement tag endpoints (create, get, getAll)

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -11,6 +11,7 @@ import { WorkStationModule } from './work_station/work_station.module';
 import { VenueRulesModule } from './venue_rules/venue_rules.module';
 import { UserStreakModule } from './user_streak/user_streak.module';
 import { AuthModule } from './auth/auth.module';
+import { TagModule } from './tag/tag.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { AuthModule } from './auth/auth.module';
     VenueRulesModule,
     UserStreakModule,
     AuthModule,
+    TagModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/server/src/tag/dto/create-tag.dto.ts
+++ b/server/src/tag/dto/create-tag.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateTagDto {
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+} 

--- a/server/src/tag/dto/tag.dto.ts
+++ b/server/src/tag/dto/tag.dto.ts
@@ -1,0 +1,4 @@
+export class TagDto {
+  id: number;
+  name: string;
+} 

--- a/server/src/tag/tag.controller.spec.ts
+++ b/server/src/tag/tag.controller.spec.ts
@@ -1,15 +1,29 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TagController } from './tag.controller';
+import { TagService } from './tag.service';
+import { Tag } from './tag.entity';
 
 describe('TagController', () => {
   let controller: TagController;
+  let service: TagService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TagController],
+      providers: [
+        {
+          provide: TagService,
+          useValue: {
+            create: jest.fn(),
+            findOne: jest.fn(),
+            findAll: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<TagController>(TagController);
+    service = module.get<TagService>(TagService);
   });
 
   it('should be defined', () => {

--- a/server/src/tag/tag.controller.ts
+++ b/server/src/tag/tag.controller.ts
@@ -1,4 +1,24 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, ParseIntPipe } from '@nestjs/common';
+import { TagService } from './tag.service';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { TagDto } from './dto/tag.dto';
 
-@Controller('tag')
-export class TagController {}
+@Controller('tags')
+export class TagController {
+  constructor(private readonly tagService: TagService) {}
+
+  @Post()
+  async createTag(@Body() createTagDto: CreateTagDto): Promise<TagDto> {
+    return this.tagService.create(createTagDto);
+  }
+
+  @Get(':id')
+  async getTag(@Param('id', ParseIntPipe) id: number): Promise<TagDto> {
+    return this.tagService.findOne(id);
+  }
+
+  @Get()
+  async getAllTags(): Promise<TagDto[]> {
+    return this.tagService.findAll();
+  }
+}

--- a/server/src/tag/tag.module.ts
+++ b/server/src/tag/tag.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { TagService } from './tag.service';
 import { TagController } from './tag.controller';
+import { Tag } from './tag.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Tag])],
   providers: [TagService],
-  controllers: [TagController]
+  controllers: [TagController],
+  exports: [TagService]
 })
 export class TagModule {}

--- a/server/src/tag/tag.service.ts
+++ b/server/src/tag/tag.service.ts
@@ -1,4 +1,40 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Tag } from './tag.entity';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { TagDto } from './dto/tag.dto';
 
 @Injectable()
-export class TagService {}
+export class TagService {
+  constructor(
+    @InjectRepository(Tag)
+    private tagRepository: Repository<Tag>,
+  ) {}
+
+  async create(createTagDto: CreateTagDto): Promise<TagDto> {
+    const tag = this.tagRepository.create(createTagDto);
+    const savedTag = await this.tagRepository.save(tag);
+    return this.mapToDto(savedTag);
+  }
+
+  async findOne(id: number): Promise<TagDto> {
+    const tag = await this.tagRepository.findOne({ where: { id } });
+    if (!tag) {
+      throw new NotFoundException(`Tag with ID "${id}" not found`);
+    }
+    return this.mapToDto(tag);
+  }
+
+  async findAll(): Promise<TagDto[]> {
+    const tags = await this.tagRepository.find();
+    return tags.map(tag => this.mapToDto(tag));
+  }
+
+  private mapToDto(tag: Tag): TagDto {
+    const tagDto = new TagDto();
+    tagDto.id = tag.id;
+    tagDto.name = tag.name;
+    return tagDto;
+  }
+}


### PR DESCRIPTION
This PR implements the following tag endpoints:

- `POST /tags` - Create a new tag
- `GET /tags` - Get all tags
- `GET /tags/:id` - Get a specific tag by ID

Changes include:
- Created DTOs for tag creation and response
- Implemented the TagService with CRUD operations
- Updated TagController with the endpoints
- Added proper test setup for TagController
- Updated the app module to include the TagModule