### PR TITLE
feat: implement password reset flow with email OTP verification

### DIFF
--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -12,6 +12,9 @@ import { LoginUserDTO } from './dto/login-user.dto';
 import { GetUser } from './get-user.decorator';
 import { AuthGuard } from '@nestjs/passport';
 import { StaffAuthGuard } from './permissions/jwt-staff-permission-authguard';
+import { RequestPasswordResetDTO } from './dto/request-password-reset.dto';
+import { VerifyOtpDTO } from './dto/verify-otp.dto';
+import { ResetPasswordDTO } from './dto/reset-password.dto';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -65,6 +68,34 @@ export class AuthController {
   test() {
     return {
       message: 'Test successful',
+      statusCode: 200,
+    };
+  }
+
+  @Post('password-reset/request')
+  async requestPasswordReset(@Body() dto: RequestPasswordResetDTO) {
+    await this.authService.requestPasswordReset(dto);
+    return {
+      message: 'Password reset OTP sent to your email',
+      statusCode: 200,
+    };
+  }
+
+  @Post('password-reset/verify-otp')
+  async verifyOTP(@Body() dto: VerifyOtpDTO) {
+    const result = await this.authService.verifyOTP(dto);
+    return {
+      message: 'OTP verified successfully',
+      data: result,
+      statusCode: 200,
+    };
+  }
+
+  @Post('password-reset/reset')
+  async resetPassword(@Body() dto: ResetPasswordDTO) {
+    await this.authService.resetPassword(dto);
+    return {
+      message: 'Password reset successful',
       statusCode: 200,
     };
   }

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { UsersModule } from 'src/users/users.module';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { PassportModule } from '@nestjs/passport';
+import { TaskModule } from 'src/task/task.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { PassportModule } from '@nestjs/passport';
       signOptions: { expiresIn: '1d' },
     }),
     UsersModule,
+    TaskModule,
   ],
   providers: [AuthService, JwtStrategy],
   controllers: [AuthController],

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -13,6 +13,11 @@ import { LoginResponse } from './types/login-response';
 import { LoginUserDTO } from './dto/login-user.dto';
 import * as bc from 'bcrypt';
 import { RedisService } from 'src/common/utils/redis.service';
+import { RequestPasswordResetDTO } from './dto/request-password-reset.dto';
+import { VerifyOtpDTO } from './dto/verify-otp.dto';
+import { ResetPasswordDTO } from './dto/reset-password.dto';
+import { TaskService } from 'src/task/task.service';
+import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class AuthService {
@@ -20,6 +25,7 @@ export class AuthService {
     private userService: UsersService,
     private jwtService: JwtService,
     private redisService: RedisService,
+    private taskService: TaskService,
   ) {}
 
   async registerAdminUser(
@@ -82,5 +88,106 @@ export class AuthService {
       throw new HttpException('User with the email does not exists', 404);
     }
     return user;
+  }
+
+  async requestPasswordReset(dto: RequestPasswordResetDTO): Promise<void> {
+    const { email } = dto;
+    
+    // Check if user exists
+    const user = await this.userService.findUserByEmail(email);
+    if (!user) {
+      throw new HttpException('User with this email does not exist', 404);
+    }
+    
+    // Generate OTP
+    const otp = this.generateOTP();
+    
+    // Store OTP in Redis with 15 minutes expiry
+    const otpKey = `password_reset_otp_${email}`;
+    await this.redisService.set(otpKey, otp, 15 * 60); // 15 minutes TTL
+    
+    // Send OTP email
+    const emailData = {
+      to: email,
+      subject: 'Password Reset OTP',
+      text: `Your OTP for password reset is: ${otp}. This code will expire in 15 minutes.`,
+    };
+    
+    await this.taskService.sendMailTask(emailData);
+  }
+
+  async verifyOTP(dto: VerifyOtpDTO): Promise<{ resetToken: string }> {
+    const { email, otp } = dto;
+    
+    // Get OTP from Redis
+    const otpKey = `password_reset_otp_${email}`;
+    const storedOTP = await this.redisService.get(otpKey);
+    
+    if (!storedOTP) {
+      throw new HttpException('OTP expired or not found', 400);
+    }
+    
+    if (storedOTP !== otp) {
+      throw new HttpException('Invalid OTP', 400);
+    }
+    
+    // OTP verified, generate reset token
+    const resetToken = uuidv4();
+    const resetTokenKey = `password_reset_token_${email}`;
+    
+    // Store reset token in Redis with 15 minutes expiry
+    await this.redisService.set(resetTokenKey, resetToken, 15 * 60);
+    
+    // Delete the used OTP
+    await this.redisService.del(otpKey);
+    
+    return { resetToken };
+  }
+
+  async resetPassword(dto: ResetPasswordDTO): Promise<void> {
+    const { email, resetToken, newPassword } = dto;
+    
+    // Verify reset token
+    const resetTokenKey = `password_reset_token_${email}`;
+    const storedToken = await this.redisService.get(resetTokenKey);
+    
+    if (!storedToken) {
+      throw new HttpException('Reset token expired or not found', 400);
+    }
+    
+    if (storedToken !== resetToken) {
+      throw new HttpException('Invalid reset token', 400);
+    }
+    
+    // Get user
+    const user = await this.userService.findUserByEmail(email);
+    if (!user) {
+      throw new HttpException('User not found', 404);
+    }
+    
+    // Hash new password
+    const salt = await bc.genSalt();
+    const hashedPassword = await bc.hash(newPassword, salt);
+    
+    // Update user password
+    user.password = hashedPassword;
+    await this.userService.updateUser(user);
+    
+    // Delete reset token
+    await this.redisService.del(resetTokenKey);
+    
+    // Send confirmation email
+    const emailData = {
+      to: email,
+      subject: 'Password Reset Successful',
+      text: 'Your password has been reset successfully.',
+    };
+    
+    await this.taskService.sendMailTask(emailData);
+  }
+
+  private generateOTP(): string {
+    // Generate a random 6-digit OTP
+    return Math.floor(100000 + Math.random() * 900000).toString();
   }
 }

--- a/server/src/auth/dto/request-password-reset.dto.ts
+++ b/server/src/auth/dto/request-password-reset.dto.ts
@@ -1,0 +1,7 @@
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class RequestPasswordResetDTO {
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+} 

--- a/server/src/auth/dto/reset-password.dto.ts
+++ b/server/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,16 @@
+import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class ResetPasswordDTO {
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  @IsNotEmpty()
+  @IsString()
+  resetToken: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @MinLength(6, { message: 'Password must be at least 6 characters long' })
+  newPassword: string;
+} 

--- a/server/src/auth/dto/verify-otp.dto.ts
+++ b/server/src/auth/dto/verify-otp.dto.ts
@@ -1,0 +1,12 @@
+import { IsEmail, IsNotEmpty, IsString, Length } from 'class-validator';
+
+export class VerifyOtpDTO {
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Length(6, 6, { message: 'OTP must be exactly 6 characters' })
+  otp: string;
+} 

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -223,4 +223,8 @@ export class UsersService {
     // Save the updated user
     return await this.userRepo.save(user);
   }
+
+  async updateUser(user: User): Promise<User> {
+    return await this.userRepo.save(user);
+  }
 }


### PR DESCRIPTION
## Description
This PR adds a secure password reset flow with email OTP verification.

## Features
- Three-step password reset process:
  1. Request password reset by email
  2. Verify OTP received by email
  3. Reset password with a valid reset token

## Implementation Details
- Added three new endpoints to the auth controller:
  - POST /auth/password-reset/request - Sends OTP to user's email
  - POST /auth/password-reset/verify-otp - Verifies OTP and provides reset token
  - POST /auth/password-reset/reset - Resets password with valid token

## Security Features
- 6-digit OTP sent to user's email
- OTPs expire after 15 minutes
- Reset tokens expire after 15 minutes
- Single-use OTPs and tokens (invalidated after use)
- Email notifications at each step of the process

## Testing
The endpoints can be tested using Postman with the following requests:

1. Request OTP:
```json
POST /auth/password-reset/request
{
  "email": "user@example.com"
}
```

2. Verify OTP:
```json
POST /auth/password-reset/verify-otp
{
  "email": "user@example.com",
  "otp": "123456"
}
```

3. Reset Password:
```json
POST /auth/password-reset/reset
{
  "email": "user@example.com",
  "resetToken": "[token from step 2]",
  "newPassword": "newSecurePassword123"
}
